### PR TITLE
feat: allow updating container resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This project is built upon the excellent open-source project [ProxmoxMCP](https:
   - `start_container` - Start LXC container
   - `stop_container` - Stop LXC container
   - `restart_container` - Restart LXC container (forcefully/gracefully)
+  - `update_container_resources` - Adjust container CPU, memory, or extend disk
 
 - 📊 **Enhanced Monitoring and Display**
   - Improved storage pool status monitoring

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -49,6 +49,7 @@ from .tools.definitions import (
     START_CONTAINER_DESC,
     STOP_CONTAINER_DESC,
     RESTART_CONTAINER_DESC,
+    UPDATE_CONTAINER_RESOURCES_DESC,
     GET_STORAGE_DESC,
     GET_CLUSTER_STATUS_DESC
 )
@@ -224,6 +225,24 @@ class ProxmoxMCPServer:
         ):
             return self.container_tools.restart_container(
                selector=selector, timeout_seconds=timeout_seconds, format_style=format_style
+            )
+
+        @self.mcp.tool(description=UPDATE_CONTAINER_RESOURCES_DESC)
+        def update_container_resources(
+            selector: Annotated[str, Field(description="CT selector (see start_container)")],
+            cores: Annotated[Optional[int], Field(description="New CPU core count", ge=1)] = None,
+            memory: Annotated[Optional[int], Field(description="New memory limit in MiB", ge=16)] = None,
+            disk_gb: Annotated[Optional[int], Field(description="Additional disk size in GiB", ge=1)] = None,
+            disk: Annotated[str, Field(description="Disk to resize", default="rootfs")] = "rootfs",
+            format_style: Annotated[Literal["pretty","json"], Field(description="Output format")] = "pretty",
+        ):
+            return self.container_tools.update_container_resources(
+                selector=selector,
+                cores=cores,
+                memory=memory,
+                disk_gb=disk_gb,
+                disk=disk,
+                format_style=format_style,
             )
 
 

--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -451,3 +451,64 @@ class ContainerTools(ProxmoxTool):
 
         except Exception as e:
             return self._err("Failed to restart container(s)", e)
+
+    def update_container_resources(
+        self,
+        selector: str,
+        cores: Optional[int] = None,
+        memory: Optional[int] = None,
+        disk_gb: Optional[int] = None,
+        disk: str = "rootfs",
+        format_style: str = "pretty",
+    ) -> List[Content]:
+        """Update container CPU/memory limits and/or extend disk size.
+
+        Parameters:
+            selector: Container selector (same grammar as start_container)
+            cores: New CPU core count
+            memory: New memory limit in MiB
+            disk_gb: Additional disk size to add in GiB
+            disk: Disk identifier to resize (default 'rootfs')
+            format_style: Output format ('pretty' or 'json')
+        """
+
+        try:
+            targets = self._resolve_targets(selector)
+            if not targets:
+                return self._err("No containers matched the selector", ValueError(selector))
+
+            results: List[Dict[str, Any]] = []
+            for node, vmid, label in targets:
+                rec: Dict[str, Any] = {"ok": True, "node": node, "vmid": vmid, "name": label}
+                changes: List[str] = []
+
+                try:
+                    update_params: Dict[str, Any] = {}
+                    if cores is not None:
+                        update_params["cores"] = cores
+                        changes.append(f"cores={cores}")
+                    if memory is not None:
+                        update_params["memory"] = memory
+                        changes.append(f"memory={memory}MiB")
+
+                    if update_params:
+                        self.proxmox.nodes(node).lxc(vmid).config.post(**update_params)
+
+                    if disk_gb is not None:
+                        size_str = f"+{disk_gb}G"
+                        self.proxmox.nodes(node).lxc(vmid).resize.post(disk=disk, size=size_str)
+                        changes.append(f"{disk}+={disk_gb}G")
+
+                    rec["message"] = ", ".join(changes) if changes else "no changes"
+                except Exception as e:
+                    rec["ok"] = False
+                    rec["error"] = str(e)
+
+                results.append(rec)
+
+            if format_style == "json":
+                return self._json_fmt(results)
+            return self._render_action_result("Update Container Resources", results)
+
+        except Exception as e:
+            return self._err("Failed to update container(s)", e)

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -133,6 +133,15 @@ RESTART_CONTAINER_DESC = """Restart LXC containers (reboot).
 selector: same grammar as start_container
 """
 
+UPDATE_CONTAINER_RESOURCES_DESC = """Update resources for one or more LXC containers.
+
+selector: same grammar as start_container
+cores: New CPU core count (optional)
+memory: New memory limit in MiB (optional)
+disk_gb: Additional disk size in GiB to add (optional)
+disk: Disk identifier to resize (default 'rootfs')
+"""
+
 # Storage tool descriptions
 GET_STORAGE_DESC = """List storage pools across the cluster with their usage and configuration.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -60,6 +60,7 @@ async def test_list_tools(server):
     assert "get_vms" in tool_names
     assert "get_containers" in tool_names
     assert "execute_vm_command" in tool_names
+    assert "update_container_resources" in tool_names
 
 @pytest.mark.asyncio
 async def test_get_nodes(server, mock_proxmox):
@@ -123,6 +124,28 @@ async def test_get_containers(server, mock_proxmox):
     assert len(result) > 0
     assert result[0]["name"] == "container1"
     assert result[1]["name"] == "container2"
+
+@pytest.mark.asyncio
+async def test_update_container_resources(server, mock_proxmox):
+    """Test update_container_resources tool."""
+    mock_proxmox.return_value.nodes.get.return_value = [{"node": "node1", "status": "online"}]
+    mock_proxmox.return_value.nodes.return_value.lxc.get.return_value = [
+        {"vmid": "200", "name": "container1", "status": "running"}
+    ]
+
+    ct_api = mock_proxmox.return_value.nodes.return_value.lxc.return_value
+    ct_api.config.post.return_value = {}
+    ct_api.resize.post.return_value = {}
+
+    response = await server.mcp.call_tool(
+        "update_container_resources",
+        {"selector": "node1:200", "cores": 2, "memory": 512, "disk_gb": 1},
+    )
+    result = json.loads(response[0].text)
+
+    assert result[0]["ok"] is True
+    ct_api.config.post.assert_called_with(cores=2, memory=512)
+    ct_api.resize.post.assert_called_with(disk="rootfs", size="+1G")
 
 @pytest.mark.asyncio
 async def test_get_storage(server, mock_proxmox):


### PR DESCRIPTION
## Summary
- add `update_container_resources` tool to adjust LXC cores, memory, and disk size
- expose new tool via MCP server and document usage
- cover resource updates with unit test

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0.0)*
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c4702d0dec8323a80c6ad938fc3030