### PR TITLE
fix: use put for container resource updates

### DIFF
--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -492,7 +492,7 @@ class ContainerTools(ProxmoxTool):
                         changes.append(f"memory={memory}MiB")
 
                     if update_params:
-                        self.proxmox.nodes(node).lxc(vmid).config.post(**update_params)
+                        self.proxmox.nodes(node).lxc(vmid).config.put(**update_params)
 
                     if disk_gb is not None:
                         size_str = f"+{disk_gb}G"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -134,7 +134,7 @@ async def test_update_container_resources(server, mock_proxmox):
     ]
 
     ct_api = mock_proxmox.return_value.nodes.return_value.lxc.return_value
-    ct_api.config.post.return_value = {}
+    ct_api.config.put.return_value = {}
     ct_api.resize.post.return_value = {}
 
     response = await server.mcp.call_tool(
@@ -144,7 +144,7 @@ async def test_update_container_resources(server, mock_proxmox):
     result = json.loads(response[0].text)
 
     assert result[0]["ok"] is True
-    ct_api.config.post.assert_called_with(cores=2, memory=512)
+    ct_api.config.put.assert_called_with(cores=2, memory=512)
     ct_api.resize.post.assert_called_with(disk="rootfs", size="+1G")
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fix update_container_resources to use PUT instead of POST when modifying container config
- adjust unit tests to reflect PUT call

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'proxmox_mcp')

------
https://chatgpt.com/codex/tasks/task_e_68c47739eb3083238037269dd2c91cbb