### PR TITLE
Use PUT for LXC disk resize

### DIFF
--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -496,7 +496,8 @@ class ContainerTools(ProxmoxTool):
 
                     if disk_gb is not None:
                         size_str = f"+{disk_gb}G"
-                        self.proxmox.nodes(node).lxc(vmid).resize.post(disk=disk, size=size_str)
+                        # Use PUT for disk resize - some Proxmox versions reject POST
+                        self.proxmox.nodes(node).lxc(vmid).resize.put(disk=disk, size=size_str)
                         changes.append(f"{disk}+={disk_gb}G")
 
                     rec["message"] = ", ".join(changes) if changes else "no changes"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -135,7 +135,7 @@ async def test_update_container_resources(server, mock_proxmox):
 
     ct_api = mock_proxmox.return_value.nodes.return_value.lxc.return_value
     ct_api.config.put.return_value = {}
-    ct_api.resize.post.return_value = {}
+    ct_api.resize.put.return_value = {}
 
     response = await server.mcp.call_tool(
         "update_container_resources",
@@ -145,7 +145,7 @@ async def test_update_container_resources(server, mock_proxmox):
 
     assert result[0]["ok"] is True
     ct_api.config.put.assert_called_with(cores=2, memory=512)
-    ct_api.resize.post.assert_called_with(disk="rootfs", size="+1G")
+    ct_api.resize.put.assert_called_with(disk="rootfs", size="+1G")
 
 @pytest.mark.asyncio
 async def test_get_storage(server, mock_proxmox):


### PR DESCRIPTION
## Summary
- switch LXC disk resize call to PUT so Proxmox accepts the request
- update tests to expect PUT when resizing container disks

## Testing
- `pytest tests/test_server.py::test_update_container_resources -q` *(fails: ModuleNotFoundError: No module named 'proxmox_mcp')*


------
https://chatgpt.com/codex/tasks/task_e_68c4ceee9e848323b7fa6af85ff6c746