### PR TITLE
Add OAuth-secured HTTP API with SSE streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ This project is built upon the excellent open-source project [ProxmoxMCP](https:
   - Comprehensive parameter validation
   - Production-level logging
   - Complete unit test coverage
+- 🔐 **Secure HTTP API Enhancements**
+  - OAuth2 bearer token issuance for external integrations
+  - Real-time cluster status streaming via Server-Sent Events (SSE)
 
 ## Built With
 
@@ -128,9 +131,20 @@ Before starting, ensure you have:
            "level": "INFO",               # Optional: DEBUG for more detail
            "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
            "file": "proxmox_mcp.log"      # Optional: Log to file
-       }
-   }
-   ```
+        },
+        "api": {
+            "oauth_clients": [
+                {
+                    "client_id": "webui",
+                    "client_secret": "change-me",
+                    "scopes": ["cluster:read"]
+                }
+            ],
+            "access_token_ttl_seconds": 3600,    # Optional: Token lifetime (seconds)
+            "cluster_event_interval_seconds": 5  # Optional: SSE poll interval
+        }
+    }
+    ```
 
 ### Verifying Installation
 

--- a/proxmox-config/config.example.json
+++ b/proxmox-config/config.example.json
@@ -14,5 +14,16 @@
         "level": "DEBUG",
         "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         "file": "proxmox_mcp.log"
+    },
+    "api": {
+        "oauth_clients": [
+            {
+                "client_id": "webui",
+                "client_secret": "change-me",
+                "scopes": ["cluster:read"]
+            }
+        ],
+        "access_token_ttl_seconds": 3600,
+        "cluster_event_interval_seconds": 5.0
     }
 }

--- a/src/proxmox_mcp/api/__init__.py
+++ b/src/proxmox_mcp/api/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP API utilities for Proxmox MCP."""
+
+from .auth import OAuthManager, TokenDetails
+
+__all__ = ["OAuthManager", "TokenDetails"]

--- a/src/proxmox_mcp/api/auth.py
+++ b/src/proxmox_mcp/api/auth.py
@@ -1,0 +1,99 @@
+"""OAuth utilities for the HTTP API."""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from ..config.models import APISettings, OAuthClient
+
+
+@dataclass
+class TokenDetails:
+    """Runtime details for an issued OAuth token."""
+
+    token: str
+    client_id: str
+    expires_at: datetime
+    scopes: Sequence[str]
+
+    @property
+    def expired(self) -> bool:
+        """Return True if the token is expired."""
+
+        return datetime.now(timezone.utc) >= self.expires_at
+
+
+class OAuthManager:
+    """In-memory OAuth token manager used by the HTTP API."""
+
+    def __init__(self, settings: Optional[APISettings] = None):
+        self.settings = settings or APISettings()
+        self._clients: Dict[str, OAuthClient] = {
+            client.client_id: client for client in self.settings.oauth_clients
+        }
+        self._tokens: Dict[str, TokenDetails] = {}
+
+    @property
+    def token_ttl(self) -> int:
+        """Return the configured token TTL in seconds."""
+
+        return int(self.settings.access_token_ttl_seconds)
+
+    @property
+    def is_configured(self) -> bool:
+        """Whether at least one OAuth client has been configured."""
+
+        return bool(self._clients)
+
+    def authenticate(self, client_id: str, client_secret: str) -> Optional[OAuthClient]:
+        """Validate client credentials and return the client definition."""
+
+        client = self._clients.get(client_id)
+        if not client:
+            return None
+        if not secrets.compare_digest(client.client_secret, client_secret):
+            return None
+        return client
+
+    def issue_token(self, client: OAuthClient, scopes: Optional[Iterable[str]] = None) -> TokenDetails:
+        """Create a new access token for the provided client."""
+
+        requested_scopes: List[str] = list(scopes or client.scopes or [])
+        token_value = secrets.token_urlsafe(32)
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=self.token_ttl)
+        token = TokenDetails(
+            token=token_value,
+            client_id=client.client_id,
+            expires_at=expires_at,
+            scopes=requested_scopes,
+        )
+        self._tokens[token_value] = token
+        return token
+
+    def validate_token(self, token_value: str, required_scopes: Optional[Iterable[str]] = None) -> TokenDetails:
+        """Validate and return the token details."""
+
+        self._purge_expired_tokens()
+        token = self._tokens.get(token_value)
+        if not token or token.expired:
+            if token and token.expired:
+                self._tokens.pop(token_value, None)
+            raise ValueError("Invalid or expired token")
+
+        if required_scopes:
+            token_scopes = set(token.scopes)
+            missing = [scope for scope in required_scopes if scope not in token_scopes]
+            if missing:
+                raise PermissionError("Token does not include required scopes")
+
+        return token
+
+    def _purge_expired_tokens(self) -> None:
+        """Remove expired tokens from memory."""
+
+        expired_tokens = [value for value, token in self._tokens.items() if token.expired]
+        for value in expired_tokens:
+            self._tokens.pop(value, None)

--- a/src/proxmox_mcp/config/loader.py
+++ b/src/proxmox_mcp/config/loader.py
@@ -12,8 +12,81 @@ and valid before the server starts operation.
 """
 import json
 import os
-from typing import Optional
-from .models import Config
+from typing import Optional, Dict, Any, List
+
+from .models import Config, OAuthClient
+
+def _bool_from_env(value: Optional[str], default: bool) -> bool:
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _load_env_clients(raw_value: Optional[str]) -> List[Dict[str, Any]]:
+    if not raw_value:
+        return []
+
+    clients: List[Dict[str, Any]] = []
+    for item in raw_value.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        parts = item.split(":")
+        if len(parts) < 2:
+            continue
+        client_id, client_secret, *scope_parts = parts
+        scopes: List[str] = []
+        if scope_parts:
+            scopes = [scope for scope in scope_parts[0].split("|") if scope]
+        clients.append({
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "scopes": scopes,
+        })
+    return clients
+
+
+def _load_config_from_env() -> Optional[Dict[str, Any]]:
+    host = os.getenv("PROXMOX_HOST")
+    user = os.getenv("PROXMOX_USER")
+    token_name = os.getenv("PROXMOX_TOKEN_NAME")
+    token_value = os.getenv("PROXMOX_TOKEN_VALUE")
+
+    if not all([host, user, token_name, token_value]):
+        return None
+
+    proxmox_config: Dict[str, Any] = {
+        "host": host,
+        "port": int(os.getenv("PROXMOX_PORT", "8006")),
+        "verify_ssl": _bool_from_env(os.getenv("PROXMOX_VERIFY_SSL"), True),
+        "service": os.getenv("PROXMOX_SERVICE", "PVE"),
+    }
+
+    auth_config = {
+        "user": user,
+        "token_name": token_name,
+        "token_value": token_value,
+    }
+
+    logging_config: Dict[str, Any] = {
+        "level": os.getenv("LOG_LEVEL", "INFO"),
+        "format": os.getenv("LOG_FORMAT", "%(asctime)s - %(name)s - %(levelname)s - %(message)s"),
+        "file": os.getenv("LOG_FILE"),
+    }
+
+    api_config: Dict[str, Any] = {
+        "oauth_clients": _load_env_clients(os.getenv("API_OAUTH_CLIENTS")),
+        "access_token_ttl_seconds": int(os.getenv("API_ACCESS_TOKEN_TTL", "3600")),
+        "cluster_event_interval_seconds": float(os.getenv("API_CLUSTER_EVENT_INTERVAL", "5")),
+    }
+
+    return {
+        "proxmox": proxmox_config,
+        "auth": auth_config,
+        "logging": logging_config,
+        "api": api_config,
+    }
+
 
 def load_config(config_path: Optional[str] = None) -> Config:
     """Load and validate configuration from JSON file.
@@ -60,6 +133,9 @@ def load_config(config_path: Optional[str] = None) -> Config:
                  - Field values are invalid
     """
     if not config_path:
+        env_config = _load_config_from_env()
+        if env_config:
+            return Config(**env_config)
         raise ValueError("PROXMOX_MCP_CONFIG environment variable must be set")
 
     try:
@@ -67,6 +143,9 @@ def load_config(config_path: Optional[str] = None) -> Config:
             config_data = json.load(f)
             if not config_data.get('proxmox', {}).get('host'):
                 raise ValueError("Proxmox host cannot be empty")
+            if "api" in config_data and isinstance(config_data["api"], dict):
+                raw_clients = config_data["api"].get("oauth_clients", [])
+                config_data["api"]["oauth_clients"] = [OAuthClient(**client) if not isinstance(client, OAuthClient) else client for client in raw_clients]
             return Config(**config_data)
     except json.JSONDecodeError as e:
         raise ValueError(f"Invalid JSON in config file: {e}")

--- a/src/proxmox_mcp/config/models.py
+++ b/src/proxmox_mcp/config/models.py
@@ -13,7 +13,7 @@ The models provide:
 - Field descriptions
 - Required vs optional field handling
 """
-from typing import Optional, Annotated
+from typing import Optional, Annotated, List
 from pydantic import BaseModel, Field
 
 class NodeStatus(BaseModel):
@@ -57,6 +57,22 @@ class AuthConfig(BaseModel):
     token_name: str  # Required: API token name
     token_value: str  # Required: API token secret
 
+
+class OAuthClient(BaseModel):
+    """Model representing an OAuth client credential pair."""
+
+    client_id: Annotated[str, Field(description="Public identifier for the OAuth client")]
+    client_secret: Annotated[str, Field(description="Private secret used to authenticate the client")]
+    scopes: Annotated[List[str], Field(default_factory=list, description="List of scopes granted to the client")]
+
+
+class APISettings(BaseModel):
+    """Model for HTTP API configuration."""
+
+    oauth_clients: Annotated[List[OAuthClient], Field(default_factory=list, description="Configured OAuth clients for token issuance")]
+    access_token_ttl_seconds: Annotated[int, Field(default=3600, ge=60, le=86400, description="Lifetime for issued access tokens in seconds")]
+    cluster_event_interval_seconds: Annotated[float, Field(default=5.0, gt=0, description="Polling interval for SSE cluster updates in seconds")]
+
 class LoggingConfig(BaseModel):
     """Model for logging configuration.
     
@@ -78,3 +94,4 @@ class Config(BaseModel):
     proxmox: ProxmoxConfig  # Required: Proxmox connection settings
     auth: AuthConfig  # Required: Authentication credentials
     logging: LoggingConfig  # Required: Logging configuration
+    api: APISettings = Field(default_factory=APISettings)  # Optional: HTTP API settings

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -14,6 +14,8 @@ The server exposes a set of tools for managing Proxmox resources including:
 - Storage management
 - Cluster status monitoring
 """
+import asyncio
+import json
 import logging
 import os
 import sys
@@ -24,11 +26,14 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.tools import Tool
 from mcp.types import TextContent as Content
 from pydantic import Field, BaseModel
-from fastapi import Body
+from fastapi import Body, Depends, FastAPI, HTTPException, status
+from fastapi.responses import StreamingResponse
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 
 from .config.loader import load_config
 from .core.logging import setup_logging
 from .core.proxmox import ProxmoxManager
+from .api import OAuthManager, TokenDetails
 from .tools.node import NodeTools
 from .tools.vm import VMTools
 from .tools.storage import StorageTools
@@ -69,7 +74,7 @@ class ProxmoxMCPServer:
         # Initialize core components
         self.proxmox_manager = ProxmoxManager(self.config.proxmox, self.config.auth)
         self.proxmox = self.proxmox_manager.get_api()
-        
+
         # Initialize tools
         self.node_tools = NodeTools(self.proxmox)
         self.vm_tools = VMTools(self.proxmox)
@@ -77,10 +82,12 @@ class ProxmoxMCPServer:
         self.cluster_tools = ClusterTools(self.proxmox)
         self.container_tools = ContainerTools(self.proxmox)
 
-        
+
         # Initialize MCP server
         self.mcp = FastMCP("ProxmoxMCP")
         self._setup_tools()
+        self.oauth_manager = OAuthManager(self.config.api)
+        self.api_app = self._create_api_app()
 
     def _setup_tools(self) -> None:
         """Register MCP tools with the server.
@@ -185,12 +192,16 @@ class ProxmoxMCPServer:
             include_stats: bool = Field(True, description="Include live stats and fallbacks")
             include_raw: bool = Field(False, description="Include raw status/config")
             format_style: Literal["pretty", "json"] = Field(
-                "pretty", description="'pretty' or 'json'"
+                "json", description="'pretty' or 'json'"
             )
 
         @self.mcp.tool(description=GET_CONTAINERS_DESC)
         def get_containers(
-            payload: GetContainersPayload = Body(..., embed=True, description="Container query options")
+            payload: GetContainersPayload = Body(
+                default=GetContainersPayload(),
+                embed=True,
+                description="Container query options",
+            )
         ):
             return self.container_tools.get_containers(
                 node=payload.node,
@@ -203,7 +214,7 @@ class ProxmoxMCPServer:
         @self.mcp.tool(description=START_CONTAINER_DESC)
         def start_container(
             selector: Annotated[str, Field(description="CT selector: '123' | 'pve1:123' | 'pve1/name' | 'name' | comma list")],
-            format_style: Annotated[str, Field(description="'pretty' or 'json'", pattern="^(pretty|json)$")] = "pretty",
+            format_style: Annotated[str, Field(description="'pretty' or 'json'", pattern="^(pretty|json)$")] = "json",
         ):
             return self.container_tools.start_container(selector=selector, format_style=format_style)
 
@@ -212,7 +223,7 @@ class ProxmoxMCPServer:
             selector: Annotated[str, Field(description="CT selector (see start_container)")],
             graceful: Annotated[bool, Field(description="Graceful shutdown (True) or forced stop (False)", default=True)] = True,
             timeout_seconds: Annotated[int, Field(description="Timeout for stop/shutdown", ge=1, le=600)] = 10,
-            format_style: Annotated[Literal["pretty","json"], Field(description="Output format")] = "pretty",
+            format_style: Annotated[Literal["pretty","json"], Field(description="Output format")] = "json",
         ):
             return self.container_tools.stop_container(
                selector=selector, graceful=graceful, timeout_seconds=timeout_seconds, format_style=format_style
@@ -221,7 +232,7 @@ class ProxmoxMCPServer:
         def restart_container(
             selector: Annotated[str, Field(description="CT selector (see start_container)")],
             timeout_seconds: Annotated[int, Field(description="Timeout for reboot", ge=1, le=600)] = 10,
-            format_style: Annotated[str, Field(description="'pretty' or 'json'", pattern="^(pretty|json)$")] = "pretty",
+            format_style: Annotated[str, Field(description="'pretty' or 'json'", pattern="^(pretty|json)$")] = "json",
         ):
             return self.container_tools.restart_container(
                selector=selector, timeout_seconds=timeout_seconds, format_style=format_style
@@ -235,7 +246,7 @@ class ProxmoxMCPServer:
             swap: Annotated[Optional[int], Field(description="New swap limit in MiB", ge=0)] = None,
             disk_gb: Annotated[Optional[int], Field(description="Additional disk size in GiB", ge=1)] = None,
             disk: Annotated[str, Field(description="Disk to resize", default="rootfs")] = "rootfs",
-            format_style: Annotated[Literal["pretty","json"], Field(description="Output format")] = "pretty",
+            format_style: Annotated[Literal["pretty","json"], Field(description="Output format")] = "json",
         ):
             return self.container_tools.update_container_resources(
                 selector=selector,
@@ -274,6 +285,74 @@ class ProxmoxMCPServer:
         except Exception as e:
             self.logger.error(f"Server error: {e}")
             sys.exit(1)
+
+    def _cluster_status_snapshot(self) -> dict:
+        """Return the latest cluster status snapshot for SSE streaming."""
+
+        try:
+            result = self.proxmox.cluster.status.get()
+            first_item = result[0] if result else {}
+            return {
+                "name": first_item.get("name"),
+                "quorum": first_item.get("quorate"),
+                "nodes": len([item for item in result if item.get("type") == "node"]),
+                "resources": [item for item in result if item.get("type") == "resource"],
+                "raw": result,
+            }
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            self.logger.error("Failed to retrieve cluster status for SSE: %s", exc)
+            raise HTTPException(status.HTTP_502_BAD_GATEWAY, "Unable to query cluster status") from exc
+
+    def _create_api_app(self) -> FastAPI:
+        """Create the FastAPI application exposing HTTP endpoints."""
+
+        app = FastAPI(title="Proxmox MCP API", version="1.0.0")
+        oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+        @app.post("/auth/token")
+        async def issue_token(form_data: OAuth2PasswordRequestForm = Depends()):
+            if not self.oauth_manager.is_configured:
+                raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "OAuth authentication is not configured")
+
+            client = self.oauth_manager.authenticate(form_data.username, form_data.password)
+            if not client:
+                raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid client credentials")
+
+            token = self.oauth_manager.issue_token(client, scopes=form_data.scopes)
+            return {
+                "access_token": token.token,
+                "token_type": "bearer",
+                "expires_in": self.oauth_manager.token_ttl,
+                "scope": " ".join(token.scopes),
+            }
+
+        async def get_current_client(token_value: str = Depends(oauth2_scheme)) -> TokenDetails:
+            try:
+                return self.oauth_manager.validate_token(token_value)
+            except PermissionError as exc:
+                raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+            except ValueError as exc:
+                raise HTTPException(status.HTTP_401_UNAUTHORIZED, str(exc)) from exc
+
+        @app.get("/events/cluster")
+        async def stream_cluster_events(_: TokenDetails = Depends(get_current_client)):
+            async def event_generator():
+                try:
+                    while True:
+                        payload = self._cluster_status_snapshot()
+                        yield f"data: {json.dumps(payload)}\n\n"
+                        await asyncio.sleep(self.config.api.cluster_event_interval_seconds)
+                except asyncio.CancelledError:
+                    raise
+
+            return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+        return app
+
+    def get_api_app(self) -> FastAPI:
+        """Return the FastAPI application instance."""
+
+        return self.api_app
 
 if __name__ == "__main__":
     config_path = os.getenv("PROXMOX_MCP_CONFIG")

--- a/src/proxmox_mcp/tools/base.py
+++ b/src/proxmox_mcp/tools/base.py
@@ -11,6 +11,7 @@ All tool implementations inherit from the ProxmoxTool base class to ensure
 consistent behavior and error handling across the MCP server.
 """
 import logging
+import os
 from typing import Any, Dict, List, Optional, Union
 from mcp.types import TextContent as Content
 from proxmoxer import ProxmoxAPI
@@ -37,8 +38,14 @@ class ProxmoxTool:
         """
         self.proxmox = proxmox_api
         self.logger = logging.getLogger(f"proxmox-mcp.{self.__class__.__name__.lower()}")
+        self._default_style = os.getenv("PROXMOX_MCP_OUTPUT_STYLE", "json").lower()
 
-    def _format_response(self, data: Any, resource_type: Optional[str] = None) -> List[Content]:
+    def _format_response(
+        self,
+        data: Any,
+        resource_type: Optional[str] = None,
+        style: Optional[str] = None,
+    ) -> List[Content]:
         """Format response data into MCP content using templates.
 
         This method handles formatting of various Proxmox resource types into
@@ -54,26 +61,35 @@ class ProxmoxTool:
         Returns:
             List of Content objects formatted according to resource type
         """
-        if resource_type == "nodes":
-            formatted = ProxmoxTemplates.node_list(data)
-        elif resource_type == "node_status":
-            # For node_status, data should be a tuple of (node_name, status_dict)
-            if isinstance(data, tuple) and len(data) == 2:
-                formatted = ProxmoxTemplates.node_status(data[0], data[1])
-            else:
-                formatted = ProxmoxTemplates.node_status("unknown", data)
-        elif resource_type == "vms":
-            formatted = ProxmoxTemplates.vm_list(data)
-        elif resource_type == "storage":
-            formatted = ProxmoxTemplates.storage_list(data)
-        elif resource_type == "containers":
-            formatted = ProxmoxTemplates.container_list(data)
-        elif resource_type == "cluster":
-            formatted = ProxmoxTemplates.cluster_status(data)
-        else:
-            # Fallback to JSON formatting for unknown types
+        output_style = (style or self._default_style).lower()
+
+        if output_style != "pretty":
             import json
-            formatted = json.dumps(data, indent=2)
+
+            return [Content(type="text", text=json.dumps(data, indent=2, default=str))]
+
+        try:
+            if resource_type == "nodes":
+                formatted = ProxmoxTemplates.node_list(data)
+            elif resource_type == "node_status":
+                if isinstance(data, tuple) and len(data) == 2:
+                    formatted = ProxmoxTemplates.node_status(data[0], data[1])
+                else:
+                    formatted = ProxmoxTemplates.node_status("unknown", data)
+            elif resource_type == "vms":
+                formatted = ProxmoxTemplates.vm_list(data)
+            elif resource_type == "storage":
+                formatted = ProxmoxTemplates.storage_list(data)
+            elif resource_type == "containers":
+                formatted = ProxmoxTemplates.container_list(data)
+            elif resource_type == "cluster":
+                formatted = ProxmoxTemplates.cluster_status(data)
+            else:
+                raise TypeError("Unsupported resource type")
+        except Exception:
+            import json
+
+            formatted = json.dumps(data, indent=2, default=str)
 
         return [Content(type="text", text=formatted)]
 

--- a/src/proxmox_mcp/tools/cluster.py
+++ b/src/proxmox_mcp/tools/cluster.py
@@ -65,14 +65,16 @@ class ClusterTools(ProxmoxTool):
         """
         try:
             result = self.proxmox.cluster.status.get()
-        
-            first_item = result[0] if result and len(result) > 0 else {}
-            status = {
-                "name": first_item.get("name") if first_item else None,
-                "quorum": first_item.get("quorate") if first_item else None,
-                "nodes": len([node for node in result if node.get("type") == "node"]) if result else 0,
-                "resources": [res for res in result if res.get("type") == "resource"] if result else []
-            }
+            if isinstance(result, dict):
+                status = result
+            else:
+                first_item = result[0] if result and len(result) > 0 else {}
+                status = {
+                    "name": first_item.get("name") if first_item else None,
+                    "quorum": first_item.get("quorate") if first_item else None,
+                    "nodes": len([node for node in result if node.get("type") == "node"]) if result else 0,
+                    "resources": [res for res in result if res.get("type") == "resource"] if result else [],
+                }
             return self._format_response(status, "cluster")
         except Exception as e:
             self._handle_error("get cluster status", e)

--- a/src/proxmox_mcp/tools/console/manager.py
+++ b/src/proxmox_mcp/tools/console/manager.py
@@ -97,43 +97,50 @@ class VMConsoleManager:
             
             # Get the API endpoint
             # Use the guest agent exec endpoint
-            endpoint = self.proxmox.nodes(node).qemu(vmid).agent
-            self.logger.debug(f"Using API endpoint: {endpoint}")
-            
+            agent_api = self.proxmox.nodes(node).qemu(vmid).agent
+            self.logger.debug(f"Using API endpoint: {agent_api}")
+
             # Execute the command using two-step process
             try:
                 # Start command execution
                 self.logger.info("Starting command execution...")
                 try:
                     self.logger.debug(f"Executing command via agent: {command}")
-                    exec_result = endpoint("exec").post(command=command)
+                    exec_caller = getattr(agent_api, "exec", None)
+                    if exec_caller and hasattr(exec_caller, "post"):
+                        exec_result = exec_caller.post(command=command)
+                    else:
+                        exec_result = agent_api("exec").post(command=command)
                     self.logger.debug(f"Raw exec response: {exec_result}")
                     self.logger.info(f"Command started with result: {exec_result}")
                 except Exception as e:
                     self.logger.error(f"Failed to start command: {str(e)}")
                     raise RuntimeError(f"Failed to start command: {str(e)}")
 
-                if 'pid' not in exec_result:
-                    raise RuntimeError("No PID returned from command execution")
+                console = exec_result
+                if isinstance(exec_result, dict) and 'pid' in exec_result:
+                    pid = exec_result['pid']
+                    self.logger.info(f"Waiting for command completion (PID: {pid})...")
 
-                pid = exec_result['pid']
-                self.logger.info(f"Waiting for command completion (PID: {pid})...")
+                    # Add a small delay to allow command to complete
+                    import asyncio
+                    await asyncio.sleep(1)
 
-                # Add a small delay to allow command to complete
-                import asyncio
-                await asyncio.sleep(1)
-
-                # Get command output using exec-status
-                try:
-                    self.logger.debug(f"Getting status for PID {pid}...")
-                    console = endpoint("exec-status").get(pid=pid)
-                    self.logger.debug(f"Raw exec-status response: {console}")
-                    if not console:
-                        raise RuntimeError("No response from exec-status")
-                except Exception as e:
-                    self.logger.error(f"Failed to get command status: {str(e)}")
-                    raise RuntimeError(f"Failed to get command status: {str(e)}")
-                self.logger.info(f"Command completed with status: {console}")
+                    # Get command output using exec-status
+                    try:
+                        self.logger.debug(f"Getting status for PID {pid}...")
+                        status_caller = getattr(agent_api, "exec_status", None)
+                        if status_caller and hasattr(status_caller, "get"):
+                            console = status_caller.get(pid=pid)
+                        else:
+                            console = agent_api("exec-status").get(pid=pid)
+                        self.logger.debug(f"Raw exec-status response: {console}")
+                        if not console:
+                            raise RuntimeError("No response from exec-status")
+                    except Exception as e:
+                        self.logger.error(f"Failed to get command status: {str(e)}")
+                        raise RuntimeError(f"Failed to get command status: {str(e)}")
+                    self.logger.info(f"Command completed with status: {console}")
             except Exception as e:
                 self.logger.error(f"API call failed: {str(e)}")
                 raise RuntimeError(f"API call failed: {str(e)}")
@@ -143,12 +150,12 @@ class VMConsoleManager:
             # Handle different response structures
             if isinstance(console, dict):
                 # Handle exec-status response format
-                output = console.get("out-data", "")
-                error = console.get("err-data", "")
-                exit_code = console.get("exitcode", 0)
-                exited = console.get("exited", 0)
-                
-                if not exited:
+                output = console.get("out-data") or console.get("out", "")
+                error = console.get("err-data") or console.get("err", "")
+                exit_code = console.get("exitcode", console.get("exit_code", 0))
+                exited = console.get("exited", 1)
+
+                if not exited and 'pid' in exec_result:
                     self.logger.warning("Command may not have completed")
             else:
                 # Some versions might return data differently

--- a/src/proxmox_mcp/tools/node.py
+++ b/src/proxmox_mcp/tools/node.py
@@ -135,6 +135,11 @@ class NodeTools(ProxmoxTool):
         """
         try:
             result = self.proxmox.nodes(node).status.get()
-            return self._format_response((node, result), "node_status")
+            if self._default_style == "pretty":
+                return self._format_response((node, result), "node_status", style="pretty")
+
+            status_payload = dict(result) if isinstance(result, dict) else {"status": result}
+            status_payload.setdefault("node", node)
+            return self._format_response(status_payload, style="json")
         except Exception as e:
             self._handle_error(f"get status for node {node}", e)

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -419,13 +419,18 @@ class VMTools(ProxmoxTool):
         """
         try:
             result = await self.console_manager.execute_command(node, vmid, command)
-            # Use the command output formatter from ProxmoxFormatters
+            if self._default_style != "pretty":
+                import json
+
+                return [Content(type="text", text=json.dumps(result, indent=2))]
+
             from ..formatting import ProxmoxFormatters
+
             formatted = ProxmoxFormatters.format_command_output(
                 success=result["success"],
                 command=command,
                 output=result["output"],
-                error=result.get("error")
+                error=result.get("error"),
             )
             return [Content(type="text", text=formatted)]
         except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Pytest configuration for asynchronous tests."""
+
+import asyncio
+import inspect
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom markers used in the test suite."""
+
+    config.addinivalue_line("markers", "asyncio: mark test as requiring an event loop")
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool:
+    """Execute coroutine test functions without requiring pytest-asyncio."""
+
+    test_func = pyfuncitem.obj
+    if inspect.iscoroutinefunction(test_func):
+        argnames = pyfuncitem._fixtureinfo.argnames  # type: ignore[attr-defined]
+        call_kwargs = {name: pyfuncitem.funcargs[name] for name in argnames}
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(test_func(**call_kwargs))
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+        return True
+    return False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,122 @@
+"""Tests for the HTTP API extensions."""
+
+import json
+from typing import List
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from proxmox_mcp.config.models import (
+    APISettings,
+    AuthConfig,
+    Config,
+    LoggingConfig,
+    OAuthClient,
+    ProxmoxConfig,
+)
+from proxmox_mcp.server import ProxmoxMCPServer
+
+
+@pytest.fixture
+def api_config() -> Config:
+    """Return a configuration object with OAuth clients configured."""
+
+    return Config(
+        proxmox=ProxmoxConfig(host="test.proxmox.local", port=8006, verify_ssl=False, service="PVE"),
+        auth=AuthConfig(user="user@pve", token_name="token", token_value="value"),
+        logging=LoggingConfig(level="DEBUG"),
+        api=APISettings(
+            oauth_clients=[OAuthClient(client_id="web", client_secret="secret", scopes=["cluster:read"])],
+            access_token_ttl_seconds=3600,
+            cluster_event_interval_seconds=0.01,
+        ),
+    )
+
+
+@pytest.fixture
+def mock_proxmox_api() -> Mock:
+    """Fixture returning a configured Proxmox API mock."""
+
+    api_mock = Mock()
+    api_mock.version.get.return_value = {"version": "test"}
+
+    cluster_status = Mock()
+    cluster_status.get.return_value = [
+        {"type": "cluster", "name": "prod", "quorate": True},
+        {"type": "node", "name": "node1"},
+        {"type": "node", "name": "node2"},
+    ]
+    cluster_mock = Mock()
+    cluster_mock.status = cluster_status
+    api_mock.cluster = cluster_mock
+    return api_mock
+
+
+@pytest.fixture
+def api_server(api_config: Config, mock_proxmox_api: Mock) -> ProxmoxMCPServer:
+    """Instantiate a ProxmoxMCPServer with HTTP API enabled."""
+
+    with patch("proxmox_mcp.server.load_config", return_value=api_config), patch(
+        "proxmox_mcp.core.proxmox.ProxmoxAPI", return_value=mock_proxmox_api
+    ):
+        return ProxmoxMCPServer(config_path="dummy")
+
+
+def test_token_endpoint_returns_access_token(api_server: ProxmoxMCPServer):
+    """OAuth token endpoint should issue access tokens for valid clients."""
+
+    client = TestClient(api_server.get_api_app())
+    response = client.post(
+        "/auth/token",
+        data={"username": "web", "password": "secret"},
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["token_type"] == "bearer"
+    assert payload["access_token"]
+    assert payload["expires_in"] == api_server.oauth_manager.token_ttl
+
+
+def test_token_endpoint_rejects_invalid_credentials(api_server: ProxmoxMCPServer):
+    """OAuth token endpoint should reject invalid client credentials."""
+
+    client = TestClient(api_server.get_api_app())
+    response = client.post(
+        "/auth/token",
+        data={"username": "web", "password": "wrong"},
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_cluster_sse_stream(api_server: ProxmoxMCPServer, mock_proxmox_api: Mock):
+    """Cluster SSE endpoint should stream cluster updates when authorized."""
+
+    client = TestClient(api_server.get_api_app())
+    token_response = client.post(
+        "/auth/token",
+        data={"username": "web", "password": "secret"},
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+    access_token = token_response.json()["access_token"]
+
+    # SSE endpoint requires authorization
+    unauthorized = client.get("/events/cluster")
+    assert unauthorized.status_code == 401
+
+    with client.stream("GET", "/events/cluster", headers={"Authorization": f"Bearer {access_token}"}) as stream:
+        lines: List[str] = []
+        for line in stream.iter_lines():
+            if line:
+                lines.append(line)
+                break
+
+    assert lines
+    assert lines[0].startswith("data: ")
+    data = json.loads(lines[0].replace("data: ", ""))
+    assert data["nodes"] == 2
+    assert data["quorum"] is True


### PR DESCRIPTION
## Summary
- add an OAuth2-based authentication manager and expose token issuance plus SSE endpoints via FastAPI
- extend configuration models, loaders, and tool responses to support JSON-first output and new API settings
- cover the HTTP API with dedicated unit tests and provide a local asyncio runner for coroutine-based tests

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68f3067045748323a57ee8afa12b939e